### PR TITLE
Update local_quickstart.rst

### DIFF
--- a/docs/local_quickstart.rst
+++ b/docs/local_quickstart.rst
@@ -18,6 +18,6 @@ This will run the service set where you can then issue SPARQL queries directly a
 In order to run the tests, you can return to your root directory and run the following commands.
 ::
     cd..
-    BUILDKIT=0 docker build --network=mms5-test-network -t mms5-test:latest -f Dockerfile-Test .
-    docker run --network=mms5-test-network --name mms5-test-container mms5-test:latest
+    docker build -t mms5-test:latest -f Dockerfile .
+    docker run -p 8080:8080 --name mms5-test-container mms5-test:latest
     docker cp mms5-test-container:/application/build/reports/tests <directory you want to store results>/results


### PR DESCRIPTION
Removed network argument from docker build and run commands and made sure that user can connect the mms5-test container to local port 8080.